### PR TITLE
Do not suggest convert in Rosalind example

### DIFF
--- a/docs/src/rosalind/02-rna.md
+++ b/docs/src/rosalind/02-rna.md
@@ -55,7 +55,7 @@ As always, there are lots of ways you *could* do this.
 This function won't hanndle poorly formatted sequences,
 for example. Or rather, it will handle them, even though it shouldn't:
 
-### Approach 2 - BioSequences `convert()`
+### Approach 2 - BioSequences `LongRNA`
 
 As you might expect, `BioSequences.jl` has a way to do this as well.
 `BioSequences.jl` doesn't just use a `String` to represent sequences,
@@ -70,7 +70,7 @@ using BioSequences
 dna_seq = LongDNA{2}(input_dna)
 
 
-simple_transcribe(seq::LongDNA{N}) where N = convert(LongRNA{N}, seq)
+simple_transcribe(seq::LongDNA{N}) where N = LongRNA{N}(seq)
 
 rna_seq = simple_transcribe(dna_seq)
 ```


### PR DESCRIPTION
Thanks for these tutorials! :heart:

It was probably an API mistake to allow `convert`ing between mutable, heap- allocated sequences. This is because `convert` is called implicit in Julia, and converting sequences:
* Is slow compared to converting integers, causing unexpected allocations
* Creates a new, mutable struct with a separate object identity. This can lead to nasty bugs when mutating the original sequence suddenly seems to have no effect, because the observed sequence is actually a distinct copy.

